### PR TITLE
Fix npm lmdb import name

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This library provides optional compression using LZ4 that works in conjunction w
 ## Usage
 An _libmdbx_ database instance is created by using `open` export from the main module:
 ```
-import { open } from 'lmdb'; // or require
+import { open } from 'lmdbx'; // or require
 // or in deno: import { open } from 'https://deno.land/x/lmdb/mod.ts';
 let myDB = open({
 	path: 'my-db',
@@ -232,7 +232,7 @@ Here are the options that can be provided to the range methods (all are optional
 ### `db.openDB(database: string|{name:string,...})`
 _libmdbx_ supports multiple databases per environment (an environment corresponds to a single memory-mapped file). When you initialize an _libmdbx_ database with `open`, the database uses the default root database. However, you can use multiple databases per environment/file and instantiate a database for each one. If you are going to be opening many databases, make sure you set the `maxDbs` (it defaults to 12). For example, we can open multiple databases for a single environment:
 ```
-import { open } from 'lmdb';
+import { open } from 'lmdbx';
 let rootDB = open('all-my-data');
 let usersDB = myDB.openDB('users');
 let groupsDB = myDB.openDB('groups');


### PR DESCRIPTION
When using the original example from README.md in nodejs:

```
import { open } from "lmdb";
```

```
> node src/index.mjs

internal/process/esm_loader.js:74
    internalBinding('errors').triggerUncaughtException(
                              ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'lmdb' imported from /Users/timdaub/Projects/project/src/index.mjs
    at packageResolve (internal/modules/esm/resolve.js:664:9)
    at moduleResolve (internal/modules/esm/resolve.js:705:18)
    at Loader.defaultResolve [as _resolve] (internal/modules/esm/resolve.js:798:11)
    at Loader.resolve (internal/modules/esm/loader.js:100:40)
    at Loader.getModuleJob (internal/modules/esm/loader.js:246:28)
    at ModuleWrap.<anonymous> (internal/modules/esm/module_job.js:47:40)
    at link (internal/modules/esm/module_job.js:46:36) {
  code: 'ERR_MODULE_NOT_FOUND'
}
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! project@0.0.1 dev: `node src/index.mjs`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the project@0.0.1 dev script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/timdaub/.npm/_logs/2022-03-30T12_43_26_380Z-debug.log
```

Given that the official name on npm is "[lmdbx](https://www.npmjs.com/package/lmdbx)", change it works