### PR TITLE
Fix libraryUrl

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -13,7 +13,7 @@ if (!libPath || !exists(libPath)) {
         let os: string = Deno.build.os;
         os = os == 'windows' ? 'win32' : os;
         os += '-' + ARCH[Deno.build.arch];
-        let libraryUrl = 'https://cdn.jsdelivr.net/npm/lmdbs@' + (version || 'latest') +
+        let libraryUrl = 'https://cdn.jsdelivr.net/npm/lmdb@' + (version || 'latest') +
             '/prebuilds/' + os + '/node.abi93' + (os == 'win32' ? '' : '.glibc') + '.node';
         console.log('Download', libraryUrl);
         let response = await fetch(libraryUrl);


### PR DESCRIPTION
Did this ever work? Seems like a typo unless the npm package name changed.

Fixes the following error:

```
> import { open } from '../Projects/lmdbx-js/mod.ts';
Download https://cdn.jsdelivr.net/npm/lmdbs@latest/prebuilds/linux-x64/node.abi93.glibc.node
Uncaught Error: Unable to fetch https://cdn.jsdelivr.net/npm/lmdbs@latest/prebuilds/linux-x64/node.abi93.glibc.node, HTTP response: 404
    at file:///home/alex/Projects/lmdbx-js/mod.ts:24:19
```